### PR TITLE
Fix Windows "Server disconnected": use valid uv args (tool run)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -21,6 +21,8 @@
         "mcp_config": {
             "command": "uvx",
             "args": [
+                "tool",
+                "run",
                 "stats-compass-mcp",
                 "run"
             ]


### PR DESCRIPTION
## Problem

On Windows the extension fails to start with **"Stats Compass: Server disconnected"** — the MCP process launches and exits immediately.

Because `server.type` is `"uv"`, Claude Desktop ignores the `command` field, launches its **bundled `uv.exe`**, and passes `mcp_config.args` verbatim. The effective command becomes:

```
uv.exe stats-compass-mcp run
```

`uv` has no subcommand `stats-compass-mcp`, so from the Claude Desktop log:

```
error: unrecognized subcommand 'stats-compass-mcp'
Usage: uv.exe [OPTIONS] <COMMAND>
Server transport closed unexpectedly ... Server disconnected.
```

The args were written for the `uvx` entrypoint (`uvx stats-compass-mcp run`), but with `type: "uv"` they need to be a valid `uv` invocation.

## Fix

Prefix the args with `tool run`, so the effective command is `uv tool run stats-compass-mcp run` — exactly what `uvx stats-compass-mcp run` expands to (`uvx` == `uv tool run`).

```diff
 "args": [
+    "tool",
+    "run",
     "stats-compass-mcp",
     "run"
 ]
```

Verified locally with the runtime Claude Desktop bundles (`uv 0.9.7`, Windows 11): the package resolves and the server starts (first launch just downloads the heavy deps).

Fixes #2
